### PR TITLE
feat(audit): add metadata-quality compliance pack with META-01 and META-02 rules

### DIFF
--- a/packages/sdk/src/__tests__/audit.test.ts
+++ b/packages/sdk/src/__tests__/audit.test.ts
@@ -5,6 +5,7 @@ import { securityRules } from '../audit/rules/security.rules.js'
 import { memoryRules } from '../audit/rules/memory.rules.js'
 import { evaluationRules } from '../audit/rules/evaluation.rules.js'
 import { observabilityRules } from '../audit/rules/observability.rules.js'
+import { metadataRules } from '../audit/rules/metadata.rules.js'
 import type { AgentSpecManifest } from '../schema/manifest.schema.js'
 import type { ProofRecord } from '../audit/index.js'
 
@@ -14,6 +15,7 @@ const allRules = [
   ...memoryRules,
   ...evaluationRules,
   ...observabilityRules,
+  ...metadataRules,
 ]
 
 const minimalManifest: AgentSpecManifest = {
@@ -171,9 +173,9 @@ describe('evidenceLevel classification', () => {
     })
   })
 
-  it('declarative evidenceBreakdown total is 0 (no declarative rules remain)', () => {
+  it('declarative evidenceBreakdown total includes metadata-quality rules', () => {
     const report = runAudit(minimalManifest)
-    expect(report.evidenceBreakdown.declarative.total).toBe(0)
+    expect(report.evidenceBreakdown.declarative.total).toBe(2)
   })
 
   it('violations include evidenceLevel', () => {
@@ -321,5 +323,81 @@ describe('runAudit', () => {
     const report = runAudit(withSuppression)
     expect(report.suppressions.length).toBe(1)
     expect(report.suppressions[0]!.ruleId).toBe('SEC-LLM-10')
+  })
+})
+
+describe('metadata-quality rules', () => {
+  it('META-01 passes when description is set', () => {
+    const rule = metadataRules.find((r) => r.id === 'META-01')!
+    const result = rule.check(minimalManifest) // minimalManifest has description: 'A test agent'
+    expect(result.pass).toBe(true)
+  })
+
+  it('META-01 fails when description is empty', () => {
+    const noDesc: AgentSpecManifest = {
+      ...minimalManifest,
+      metadata: { ...minimalManifest.metadata, description: '   ' },
+    }
+    const rule = metadataRules.find((r) => r.id === 'META-01')!
+    const result = rule.check(noDesc)
+    expect(result.pass).toBe(false)
+    expect(result.message).toBeDefined()
+    expect(result.path).toBe('/metadata/description')
+  })
+
+  it('META-02 passes when temperature is undefined (provider default)', () => {
+    const rule = metadataRules.find((r) => r.id === 'META-02')!
+    const result = rule.check(minimalManifest) // no parameters set
+    expect(result.pass).toBe(true)
+  })
+
+  it('META-02 passes when temperature is <= 1.5', () => {
+    const safeTemp: AgentSpecManifest = {
+      ...minimalManifest,
+      spec: {
+        ...minimalManifest.spec,
+        model: { ...minimalManifest.spec.model, parameters: { temperature: 0.7 } },
+      },
+    }
+    const rule = metadataRules.find((r) => r.id === 'META-02')!
+    const result = rule.check(safeTemp)
+    expect(result.pass).toBe(true)
+  })
+
+  it('META-02 fails when temperature is > 1.5', () => {
+    const hotTemp: AgentSpecManifest = {
+      ...minimalManifest,
+      spec: {
+        ...minimalManifest.spec,
+        model: { ...minimalManifest.spec.model, parameters: { temperature: 1.8 } },
+      },
+    }
+    const rule = metadataRules.find((r) => r.id === 'META-02')!
+    const result = rule.check(hotTemp)
+    expect(result.pass).toBe(false)
+    expect(result.message).toContain('1.8')
+    expect(result.path).toBe('/spec/model/parameters/temperature')
+  })
+
+  it('runAudit with packs: [metadata-quality] returns only META- violations', () => {
+    const noDesc: AgentSpecManifest = {
+      ...minimalManifest,
+      metadata: { ...minimalManifest.metadata, description: '' },
+      spec: {
+        ...minimalManifest.spec,
+        model: { ...minimalManifest.spec.model, parameters: { temperature: 1.9 } },
+      },
+    }
+    const report = runAudit(noDesc, { packs: ['metadata-quality'] })
+    expect(report.violations.length).toBe(2)
+    for (const v of report.violations) {
+      expect(v.ruleId.startsWith('META-')).toBe(true)
+    }
+  })
+
+  it('metadata rules have declarative evidenceLevel', () => {
+    for (const rule of metadataRules) {
+      expect(rule.evidenceLevel).toBe('declarative')
+    }
   })
 })

--- a/packages/sdk/src/audit/index.ts
+++ b/packages/sdk/src/audit/index.ts
@@ -4,6 +4,7 @@ import { securityRules } from './rules/security.rules.js'
 import { memoryRules } from './rules/memory.rules.js'
 import { evaluationRules } from './rules/evaluation.rules.js'
 import { observabilityRules } from './rules/observability.rules.js'
+import { metadataRules } from './rules/metadata.rules.js'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -16,6 +17,7 @@ export type CompliancePack =
   | 'memory-hygiene'
   | 'evaluation-coverage'
   | 'observability'
+  | 'metadata-quality'
 
 export type EvidenceLevel = 'declarative' | 'probed' | 'behavioral' | 'external'
 
@@ -135,6 +137,7 @@ const ALL_RULES: AuditRule[] = [
   ...memoryRules,
   ...evaluationRules,
   ...observabilityRules,
+  ...metadataRules,
 ]
 
 /** Set of all valid audit rule IDs — single source of truth for validation. */

--- a/packages/sdk/src/audit/rules/metadata.rules.ts
+++ b/packages/sdk/src/audit/rules/metadata.rules.ts
@@ -1,0 +1,51 @@
+import type { AgentSpecManifest } from '../../schema/manifest.schema.js'
+import type { AuditRule, RuleResult } from '../index.js'
+
+export const metadataRules: AuditRule[] = [
+  {
+    id: 'META-01',
+    pack: 'metadata-quality',
+    title: 'Agent description declared',
+    description: 'Agents should have a non-empty description for fleet discovery and documentation',
+    severity: 'low',
+    evidenceLevel: 'declarative',
+    check(manifest: AgentSpecManifest): RuleResult {
+      const desc = manifest.metadata.description
+      const pass = typeof desc === 'string' && desc.trim().length > 0
+      return {
+        pass,
+        message: pass
+          ? undefined
+          : 'No description declared in metadata. Agents without descriptions are hard to discover in a fleet.',
+        path: '/metadata/description',
+        recommendation:
+          'Add a concise metadata.description explaining what the agent does',
+        references: [],
+      }
+    },
+  },
+
+  {
+    id: 'META-02',
+    pack: 'metadata-quality',
+    title: 'Model temperature is production-safe',
+    description: 'Temperature above 1.5 causes unpredictable outputs that are unsuitable for production',
+    severity: 'medium',
+    evidenceLevel: 'declarative',
+    check(manifest: AgentSpecManifest): RuleResult {
+      const temperature = manifest.spec.model.parameters?.temperature
+      if (temperature === undefined) return { pass: true }
+      const pass = temperature <= 1.5
+      return {
+        pass,
+        message: pass
+          ? undefined
+          : `Model temperature is ${temperature} — values above 1.5 produce unreliable outputs in production.`,
+        path: '/spec/model/parameters/temperature',
+        recommendation:
+          'Set spec.model.parameters.temperature to 1.0 or lower for production agents',
+        references: [],
+      }
+    },
+  },
+]

--- a/packages/sdk/src/schema/manifest.schema.ts
+++ b/packages/sdk/src/schema/manifest.schema.ts
@@ -484,6 +484,7 @@ const ComplianceSchema = z.object({
         'model-resilience',
         'evaluation-coverage',
         'observability',
+        'metadata-quality',
       ]),
     )
     .optional()


### PR DESCRIPTION
## What

Adds a new `metadata-quality` compliance pack with two audit rules:

- **META-01** (low) — Checks that `metadata.description` is non-empty. Agents without descriptions are hard to discover in fleet environments.
- **META-02** (medium) — Checks that `model.parameters.temperature` ≤ 1.5. Higher values produce unreliable outputs unsuitable for production.

## Changes

- **New**: [packages/sdk/src/audit/rules/metadata.rules.ts](cci:7://file:///Users/mehdi/projects/agentspec/packages/sdk/src/audit/rules/metadata.rules.ts:0:0-0:0)
- **Modified**: [audit/index.ts](cci:7://file:///Users/mehdi/projects/agentspec/packages/sdk/src/audit/index.ts:0:0-0:0) — import, register rules, extend [CompliancePack](cci:2://file:///Users/mehdi/projects/agentspec/packages/sdk/src/audit/index.ts:12:0-17:19) type
- **Modified**: [manifest.schema.ts](cci:7://file:///Users/mehdi/projects/agentspec/packages/sdk/src/schema/manifest.schema.ts:0:0-0:0) — add `metadata-quality` to Zod compliance packs enum
- **Modified**: [audit.test.ts](cci:7://file:///Users/mehdi/projects/agentspec/packages/sdk/src/__tests__/audit.test.ts:0:0-0:0) — 7 new test cases

## Verification

- `pnpm --filter @agentspec/sdk test` → 277/277 pass
- `pnpm --filter @agentspec/sdk typecheck` → 0 errors
- Manual: `agentspec audit` with `packs: [metadata-quality]` correctly flags/passes both rules
