### PR TITLE
feat: deploy control plane as Helm sub-component with push mode demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ DEMO_CLUSTER   := agentspec
 DEMO_OP_NS     := agentspec-system
 DEMO_AGENT_NS  := demo
 OPERATOR_IMAGE := agentspec/operator:dev
+CP_IMAGE       := agentspec/control-plane:dev
 
 # Set USE_KIND=false + KUBE_CONTEXT=<ctx> to skip kind and use an existing cluster.
 # Works out of the box with orbstack/Docker Desktop K8s (shared Docker daemon).
@@ -59,7 +60,7 @@ help:
 	@printf "    $(GREEN)demo-verify$(RESET)    Run the UAT verify script\n"
 	@printf "    $(GREEN)demo-e2e$(RESET)      Run automated e2e pytest suite (proxy+OPA+gap+events)\n"
 	@printf "    $(GREEN)demo-status$(RESET)    Show live AgentObservation phase/grade/score table\n"
-	@printf "    $(GREEN)demo-patch$(RESET)     Live patch: voice-assistant C→A + research-agent F→A\n"
+	@printf "    $(GREEN)demo-patch$(RESET)     Live patch: voice-assistant C→A, research-agent F→A, fitness-tracker push mode\n"
 	@printf "    $(GREEN)demo-reset$(RESET)     Restore agents to pre-patch state (replay the demo)\n"
 	@printf "    $(GREEN)demo-logs$(RESET)      Tail the operator logs\n"
 	@printf "    $(GREEN)demo-down$(RESET)      Delete the kind cluster\n"
@@ -174,12 +175,15 @@ demo-operator: demo-cluster
 	else \
 	  printf "\n  $(BOLD)Building operator image $(OPERATOR_IMAGE)...$(RESET)\n"; \
 	  docker build -t $(OPERATOR_IMAGE) packages/operator; \
+	  printf "\n  $(BOLD)Building control plane image $(CP_IMAGE)...$(RESET)\n"; \
+	  docker build -t $(CP_IMAGE) packages/control-plane; \
 	  if [ "$(USE_KIND)" = "true" ]; then \
-	    printf "  $(BOLD)Loading image into kind cluster '$(DEMO_CLUSTER)'...$(RESET)\n"; \
+	    printf "  $(BOLD)Loading images into kind cluster '$(DEMO_CLUSTER)'...$(RESET)\n"; \
 	    kind load docker-image $(OPERATOR_IMAGE) --name $(DEMO_CLUSTER); \
+	    kind load docker-image $(CP_IMAGE) --name $(DEMO_CLUSTER); \
 	  fi; \
 	fi
-	@printf "  $(BOLD)Deploying operator via Helm...$(RESET)\n"
+	@printf "  $(BOLD)Deploying operator + control plane via Helm...$(RESET)\n"
 	helm upgrade --install agentspec \
 	  packages/operator/helm/agentspec-operator \
 	  --kube-context $(KUBE_CONTEXT) \
@@ -187,6 +191,13 @@ demo-operator: demo-cluster
 	  --set operator.image.repository=agentspec/operator \
 	  --set operator.image.tag=dev \
 	  --set operator.image.pullPolicy=$(if $(filter true,$(USE_KIND)),Never,IfNotPresent) \
+	  --set controlPlane.enabled=true \
+	  --set controlPlane.image.repository=agentspec/control-plane \
+	  --set controlPlane.image.tag=dev \
+	  --set controlPlane.image.pullPolicy=$(if $(filter true,$(USE_KIND)),Never,IfNotPresent) \
+	  --set controlPlane.apiKey=demo-admin-key \
+	  --set-string webhook.enabled=true \
+	  --set webhook.certManager.enabled=false \
 	  --wait --timeout=120s
 
 ## Deploy all five demo agent pods + AgentObservation CRs
@@ -258,8 +269,9 @@ demo-status:
 demo-logs:
 	kubectl logs -n $(DEMO_OP_NS) --context $(KUBE_CONTEXT) deploy/agentspec-operator -f
 
-## Live patching demo — watch two agents improve in real time
+## Live patching demo — watch agents improve in real time
 ## voice-assistant: C→A (manifest-static)   research-agent: F→A (agent-sdk)
+## fitness-tracker: enable push mode → heartbeat visible in control plane
 demo-patch:
 	@echo ""
 	@printf "  $(BOLD)Live patching demo — watch grades improve in real time$(RESET)\n"
@@ -318,6 +330,19 @@ demo-patch:
 	@printf "  $(GREEN)✓ [research-agent] AFTER: score=100 grade=A phase=Healthy source=agent-sdk$(RESET)\n"
 	@printf "  violations: none\n"
 	@echo ""
+	@# ─── fitness-tracker: enable push mode (heartbeats → control plane) ─────
+	@printf "  $(BOLD)[fitness-tracker] Enabling push mode$(RESET) — SDK heartbeats → control plane\n"
+	@printf "  Agent will register + push heartbeats every 15s\n"
+	@echo ""
+	kubectl apply -f packages/operator/demo/patches/fitness-tracker-patched-deployment.yaml \
+	  --context $(KUBE_CONTEXT)
+	kubectl rollout status deployment/fitness-tracker -n $(DEMO_AGENT_NS) \
+	  --context $(KUBE_CONTEXT) --timeout=60s
+	@printf "  $(GREEN)✓ Deployment updated (push mode active)$(RESET)\n"
+	@printf "  Waiting 5s for first heartbeat...\n"
+	@sleep 5
+	@printf "  $(GREEN)✓ [fitness-tracker] now visible in control plane with heartbeat: true$(RESET)\n"
+	@echo ""
 	$(MAKE) demo-status
 
 ## Reset patched agents to original degraded state (for replaying the demo)
@@ -328,8 +353,10 @@ demo-reset:
 	  --context $(KUBE_CONTEXT)
 	kubectl apply -f packages/operator/demo/research-agent/deployment.yaml \
 	  --context $(KUBE_CONTEXT)
+	kubectl apply -f packages/operator/demo/fitness-tracker/deployment.yaml \
+	  --context $(KUBE_CONTEXT)
 	kubectl rollout status \
-	  deployment/voice-assistant deployment/research-agent \
+	  deployment/voice-assistant deployment/research-agent deployment/fitness-tracker \
 	  -n $(DEMO_AGENT_NS) --context $(KUBE_CONTEXT) --timeout=60s
 	@printf "  $(GREEN)✓ Demo reset — run 'make demo-patch' again to replay$(RESET)\n"
 	@echo ""

--- a/docs/concepts/operating-modes.md
+++ b/docs/concepts/operating-modes.md
@@ -120,7 +120,7 @@ The Operator service exposes a REST API. Access it via:
 
 **Local cluster** (kind, minikube, etc.):
 ```bash
-kubectl port-forward svc/agentspec-operator -n agentspec 8080:80
+kubectl port-forward svc/agentspec-operator-control-plane -n agentspec-system 8080:80
 # → http://localhost:8080
 ```
 
@@ -163,7 +163,7 @@ port-forward.
 For operator mode, port-forward the control plane service to your local machine:
 
 ```bash
-kubectl port-forward svc/agentspec-operator -n agentspec 8080:80
+kubectl port-forward svc/agentspec-operator-control-plane -n agentspec-system 8080:80
 ```
 
 Then configure the MCP server with env vars so all tools automatically use the cluster:
@@ -204,15 +204,19 @@ openssl rand -hex 32
 
 # Set it on the control plane (pick one):
 # Helm upgrade:
-helm upgrade agentspec-operator oci://ghcr.io/agents-oss/charts/agentspec-operator \
+helm upgrade agentspec agentspec/operator \
+  --set controlPlane.enabled=true \
   --set controlPlane.apiKey=<your-key> \
   --namespace agentspec-system
 
 # Or create the secret directly:
 kubectl create secret generic agentspec-control-plane \
   --namespace=agentspec-system \
-  --from-literal=apiKey=<your-key>
+  --from-literal=apiKey=<your-key> \
+  --from-literal=jwtSecret=$(openssl rand -hex 32)
 ```
+
+The control plane also requires `JWT_SECRET` (≥ 32 chars) for signing agent registration tokens. The Helm chart auto-derives one from `apiKey` if not set. For production, set it explicitly via `controlPlane.jwtSecret` or in the Secret.
 
 Then use the same key in your MCP config.
 
@@ -241,7 +245,7 @@ Port-forward is a **transport detail**, not a separate mode:
 | Mode | Port-forward scope | kubectl command |
 |---|---|---|
 | **Sidecar** | Per agent (one process per agent) | `kubectl port-forward deployment/<name> <local>:4001` |
-| **Operator** | Per cluster (one process, all agents) | `kubectl port-forward svc/agentspec-operator -n agentspec 8080:80` |
+| **Operator** | Per cluster (one process, all agents) | `kubectl port-forward svc/agentspec-operator-control-plane -n agentspec-system 8080:80` |
 
 VS Code manages sidecar port-forwards automatically (idle cleanup on deactivate).
 Operator port-forward is a one-time manual step.

--- a/docs/guides/add-push-mode.md
+++ b/docs/guides/add-push-mode.md
@@ -150,12 +150,49 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 ```
 
+## Kubernetes (automatic)
+
+When the AgentSpec Operator is deployed with `controlPlane.enabled=true` and `webhook.enabled=true`,
+the webhook automatically injects `AGENTSPEC_CONTROL_PLANE_URL` into every sidecar container.
+
+Agents using the AgentSpec SDK detect this env var and auto-register with the control plane:
+
+1. `POST /api/v1/register` — registers the agent and receives a JWT
+2. `POST /api/v1/heartbeat` — pushes health + gap data on a timer
+
+No manual configuration is needed per agent. The Helm chart manages the control plane URL
+and admin key via a shared Kubernetes Secret (`agentspec-control-plane`).
+
+```bash
+# Enable control plane + webhook in one command
+helm upgrade agentspec agentspec/operator \
+  --set controlPlane.enabled=true \
+  --set controlPlane.apiKey=<your-admin-key> \
+  --set webhook.enabled=true \
+  --set webhook.certManager.enabled=true
+```
+
+The control plane API requires a `JWT_SECRET` (≥ 32 chars) to sign registration tokens.
+The Helm chart auto-derives one from `apiKey` if not set explicitly. For production,
+set `controlPlane.jwtSecret` or create the Secret manually:
+
+```bash
+kubectl create secret generic agentspec-control-plane \
+  --namespace=agentspec-system \
+  --from-literal=apiKey=$(openssl rand -hex 32) \
+  --from-literal=jwtSecret=$(openssl rand -hex 32)
+```
+
+See [Operator Helm Values](../reference/operator-helm-values.md#controlplane) for the full reference.
+
 ## Configuration reference
 
 | Env var | Required | Description |
 |---------|----------|-------------|
-| `AGENTSPEC_URL` | Yes | `POST` endpoint on your control plane |
-| `AGENTSPEC_KEY` | Yes | Bearer token — sent as `Authorization: Bearer <key>` |
+| `AGENTSPEC_URL` | Yes (standalone) | `POST` endpoint on your control plane |
+| `AGENTSPEC_KEY` | Yes (standalone) | Bearer token — sent as `Authorization: Bearer <key>` |
+| `AGENTSPEC_CONTROL_PLANE_URL` | Auto (K8s) | Injected by the webhook when `controlPlane.enabled=true` |
+| `AGENTSPEC_ADMIN_KEY` | Auto (K8s) | Used for registration; injected by the webhook or set in pod env |
 
 The interval defaults to **30 seconds** and can be overridden in code. There is no env var for
 the interval — configure it at the call site.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -181,7 +181,7 @@ claude mcp add agentspec -- npx -y @agentspec/mcp
 
 Port-forward the control plane first:
 ```bash
-kubectl port-forward svc/agentspec-operator -n agentspec 8080:80
+kubectl port-forward svc/agentspec-operator-control-plane -n agentspec-system 8080:80
 ```
 
 Then add `env` to your MCP config (`.claude/settings.json` or Cursor/Windsurf equivalent):

--- a/docs/reference/operator-helm-values.md
+++ b/docs/reference/operator-helm-values.md
@@ -159,15 +159,63 @@ When `opa.enabled` is `true`, the webhook injects an OPA container alongside eve
 
 ## `controlPlane`
 
-Enables `RemoteAgentWatcher`, which polls the control plane and upserts `AgentObservation` CRs for remote agents (Bedrock, Vertex, Docker, local) into a dedicated namespace.
+Deploys the AgentSpec control plane (FastAPI REST API) as a sub-component of the Helm chart and enables `RemoteAgentWatcher`, which polls it and upserts `AgentObservation` CRs for remote agents into a dedicated namespace.
+
+When enabled, a `Deployment`, `Service`, and `Secret` are created alongside the operator. If `controlPlane.url` is left empty, the internal service URL is auto-resolved (`http://<release>-control-plane.<namespace>.svc.cluster.local`).
+
+### Quick enable
+
+```bash
+helm upgrade agentspec agentspec/operator \
+  --set controlPlane.enabled=true \
+  --set controlPlane.apiKey=<your-admin-key>
+```
+
+This creates a Kubernetes Secret `agentspec-control-plane` with:
+- `apiKey` — the admin key for the control plane API
+- `jwtSecret` — used to sign agent registration JWTs (auto-derived from `apiKey` if not set; **set explicitly in production**)
+
+### Values reference
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `controlPlane.enabled` | `false` | Enable `RemoteAgentWatcher`. |
-| `controlPlane.url` | `""` | Control plane base URL (e.g. `https://control-plane.agentspec.io`). |
-| `controlPlane.apiKey` | `""` | Admin key for `GET /api/v1/agents`. Stored in a Kubernetes Secret. |
-| `controlPlane.pollInterval` | `30` | Seconds between polls. |
-| `controlPlane.namespace` | `agentspec-remote` | Namespace where remote `AgentObservation` CRs are created. Created automatically if it does not exist. |
+| `controlPlane.enabled` | `false` | Deploy the control plane and enable `RemoteAgentWatcher`. |
+| `controlPlane.image.repository` | `ghcr.io/agents-oss/agentspec-control-plane` | Control plane container image. |
+| `controlPlane.image.tag` | `latest` | Image tag. Override with `--set controlPlane.image.tag=X.Y.Z`. |
+| `controlPlane.image.pullPolicy` | `IfNotPresent` | Image pull policy. |
+| `controlPlane.url` | `""` | Override the control plane URL. Leave empty to auto-resolve to the internal ClusterIP Service. |
+| `controlPlane.apiKey` | `""` | Admin key for the control plane API (`X-Admin-Key` header). Stored in Secret `agentspec-control-plane`. **Required** — admin endpoints return 503 until set. |
+| `controlPlane.jwtSecret` | `""` | Secret used to sign agent registration JWTs. Must be ≥ 32 characters. If empty, auto-derived from `apiKey` (not recommended for production). |
+| `controlPlane.databaseUrl` | `""` | Database URL. Defaults to local SQLite at `/data/agentspec.db`. For production use PostgreSQL: `postgresql+asyncpg://user:pass@host:5432/agentspec`. |
+| `controlPlane.pollInterval` | `30` | Seconds between `RemoteAgentWatcher` polls. |
+| `controlPlane.namespace` | `agentspec-remote` | Namespace where remote `AgentObservation` CRs are created. |
+| `controlPlane.replicas` | `1` | Replica count. |
+| `controlPlane.resources` | see values.yaml | Resource requests/limits for the control plane pod. |
+| `controlPlane.env` | `[]` | Extra environment variables for the control plane pod. |
+
+### Secret layout
+
+The Helm chart creates Secret `agentspec-control-plane` with two keys:
+
+| Key | Source | Used by |
+|-----|--------|---------|
+| `apiKey` | `controlPlane.apiKey` | Control plane (`AGENTSPEC_ADMIN_KEY`), operator (`CONTROL_PLANE_KEY`), MCP/CLI |
+| `jwtSecret` | `controlPlane.jwtSecret` or auto-derived | Control plane (`JWT_SECRET`) — signs registration JWTs |
+
+For production, create the Secret manually instead of using Helm values:
+
+```bash
+kubectl create secret generic agentspec-control-plane \
+  --namespace=agentspec-system \
+  --from-literal=apiKey=$(openssl rand -hex 32) \
+  --from-literal=jwtSecret=$(openssl rand -hex 32)
+```
+
+Then install with `controlPlane.enabled=true` but omit `controlPlane.apiKey` — the chart picks up the existing Secret.
+
+### Webhook auto-injection
+
+When both `controlPlane.enabled` and `webhook.enabled` are `true`, the operator webhook automatically injects `AGENTSPEC_CONTROL_PLANE_URL` into every sidecar container it creates. Agents using the AgentSpec SDK can then auto-register and push heartbeats without manual configuration.
 
 ---
 

--- a/packages/mcp-server/src/__tests__/listAgents.test.ts
+++ b/packages/mcp-server/src/__tests__/listAgents.test.ts
@@ -26,6 +26,7 @@ describe('listAgents — cluster mode', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8080/api/v1/agents')
     expect(result.agents).toHaveLength(2)
     expect(result.agents[0].agentName).toBe('budget-assistant')
+    expect(result.agents[0].heartbeat).toBe(true)
     expect(result.source).toBe('cluster')
   })
 
@@ -47,12 +48,42 @@ describe('listAgents — cluster mode', () => {
     expect(headers['X-Admin-Key']).toBeUndefined()
   })
 
-  it('throws on non-ok response', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' })
+  it('returns empty agents with helpful message when control plane has no agents', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '[]' })
 
-    await expect(
-      listAgents({ controlPlaneUrl: 'http://localhost:8080' }),
-    ).rejects.toThrow('401')
+    const result = JSON.parse(await listAgents({ controlPlaneUrl: 'http://localhost:8080' }))
+
+    expect(result.agents).toEqual([])
+    expect(result.source).toBe('cluster')
+    expect(result.summary.total).toBe(0)
+    expect(result.summary.message).toContain('No agents registered')
+    expect(result.summary.message).toContain('POST /api/v1/register')
+  })
+
+  it('returns summary with heartbeat counts based on lastSeen', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => CLUSTER_AGENTS })
+
+    const result = JSON.parse(await listAgents({ controlPlaneUrl: 'http://localhost:8080' }))
+
+    // Both agents have lastSeen set → both have heartbeat: true
+    expect(result.summary.total).toBe(2)
+    expect(result.summary.withHeartbeat).toBe(2)
+    expect(result.summary.withoutHeartbeat).toBe(0)
+  })
+
+  it('marks agents without lastSeen as no heartbeat', async () => {
+    const mixed = JSON.stringify([
+      { agentName: 'with-heartbeat', lastSeen: '2026-03-08T12:00:00Z' },
+      { agentName: 'no-heartbeat' },
+    ])
+    fetchMock.mockResolvedValue({ ok: true, text: async () => mixed })
+
+    const result = JSON.parse(await listAgents({ controlPlaneUrl: 'http://localhost:8080' }))
+
+    expect(result.agents[0].heartbeat).toBe(true)
+    expect(result.agents[1].heartbeat).toBe(false)
+    expect(result.summary.withHeartbeat).toBe(1)
+    expect(result.summary.withoutHeartbeat).toBe(1)
   })
 
   it('strips trailing slash from controlPlaneUrl', async () => {
@@ -63,8 +94,18 @@ describe('listAgents — cluster mode', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8080/api/v1/agents')
   })
 
-  it('returns empty agents array when cluster has none', async () => {
-    fetchMock.mockResolvedValue({ ok: true, text: async () => '[]' })
+  it('gracefully handles control plane fetch failure', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const result = JSON.parse(await listAgents({ controlPlaneUrl: 'http://localhost:8080' }))
+
+    expect(result.agents).toEqual([])
+    expect(result.source).toBe('cluster')
+    expect(result.summary.total).toBe(0)
+  })
+
+  it('gracefully handles non-ok response from control plane', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
 
     const result = JSON.parse(await listAgents({ controlPlaneUrl: 'http://localhost:8080' }))
 

--- a/packages/mcp-server/src/cluster-config.ts
+++ b/packages/mcp-server/src/cluster-config.ts
@@ -11,7 +11,7 @@ export interface ClusterConfig {
 
 export function resolveCluster(args: ClusterConfig): ClusterConfig {
   return {
-    controlPlaneUrl: args.controlPlaneUrl || process.env['AGENTSPEC_CONTROL_PLANE_URL'] || undefined,
-    adminKey: args.adminKey || process.env['AGENTSPEC_ADMIN_KEY'] || undefined,
+    controlPlaneUrl: args.controlPlaneUrl ?? process.env['AGENTSPEC_CONTROL_PLANE_URL'] ?? undefined,
+    adminKey: args.adminKey ?? process.env['AGENTSPEC_ADMIN_KEY'] ?? undefined,
   }
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -288,10 +288,24 @@ async function handleRpc(req: McpRequest): Promise<McpResponse> {
 
 // ── HTTP server ───────────────────────────────────────────────────────────────
 
+const MAX_BODY_BYTES = 1_048_576 // 1 MB
+
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
+    const contentLength = parseInt(req.headers['content-length'] ?? '0', 10)
+    if (contentLength > MAX_BODY_BYTES) {
+      return reject(new Error(`Body too large: ${contentLength} > ${MAX_BODY_BYTES}`))
+    }
     let body = ''
-    req.on('data', (chunk: Buffer) => { body += chunk.toString() })
+    let received = 0
+    req.on('data', (chunk: Buffer) => {
+      received += chunk.length
+      if (received > MAX_BODY_BYTES) {
+        req.destroy()
+        return reject(new Error('Body too large'))
+      }
+      body += chunk.toString()
+    })
     req.on('end', () => resolve(body))
     req.on('error', reject)
   })
@@ -372,8 +386,8 @@ function startHttp(): void {
       res.end(String(err))
     })
   })
-  server.listen(PORT, () => {
-    process.stderr.write(`AgentSpec MCP server listening on http://localhost:${PORT}/mcp\n`)
+  server.listen(PORT, '127.0.0.1', () => {
+    process.stderr.write(`AgentSpec MCP server listening on http://127.0.0.1:${PORT}/mcp\n`)
   })
 }
 

--- a/packages/mcp-server/src/tools/listAgents.ts
+++ b/packages/mcp-server/src/tools/listAgents.ts
@@ -11,24 +11,64 @@ interface AgentSummary {
   framework?: string
 }
 
+interface ClusterAgent {
+  agentId?: string
+  agentName: string
+  runtime?: string
+  phase?: string
+  grade?: string
+  score?: number
+  lastSeen?: string
+  heartbeat: boolean
+}
+
 export interface ListAgentsArgs {
   dir?: string
   controlPlaneUrl?: string
   adminKey?: string
 }
 
-// ── Cluster mode ─────────────────────────────────────────────────────────────
+// ── Control plane (heartbeat agents) ────────────────────────────────────────
 
-async function fetchFromCluster(controlPlaneUrl: string, adminKey?: string): Promise<string> {
+async function fetchHeartbeatAgents(controlPlaneUrl: string, adminKey?: string): Promise<ClusterAgent[]> {
   const url = `${controlPlaneUrl.replace(/\/$/, '')}/api/v1/agents`
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (adminKey) headers['X-Admin-Key'] = adminKey
 
-  const res = await fetch(url, { headers })
-  if (!res.ok) throw new Error(`GET ${url} returned ${res.status} ${res.statusText}`)
+  try {
+    const res = await fetch(url, { headers })
+    if (!res.ok) return [] // control plane may be empty or unavailable
+    const agents = JSON.parse(await res.text()) as Record<string, unknown>[]
+    return agents.map(a => ({
+      ...a,
+      heartbeat: a.lastSeen != null,
+    }) as ClusterAgent)
+  } catch {
+    return []
+  }
+}
 
-  const agents = JSON.parse(await res.text())
-  return JSON.stringify({ agents, source: 'cluster', total: agents.length })
+// ── Cluster mode ─────────────────────────────────────────────────────────────
+
+async function fetchFromCluster(controlPlaneUrl: string, adminKey?: string): Promise<string> {
+  const heartbeatAgents = await fetchHeartbeatAgents(controlPlaneUrl, adminKey)
+
+  const total = heartbeatAgents.length
+  const withHeartbeat = heartbeatAgents.filter(a => a.heartbeat).length
+
+  return JSON.stringify({
+    agents: heartbeatAgents,
+    source: 'cluster',
+    total,
+    summary: {
+      total,
+      withHeartbeat,
+      withoutHeartbeat: total - withHeartbeat,
+      message: total === 0
+        ? 'No agents registered in the control plane. Agents need to call POST /api/v1/register and push heartbeats via the SDK push mode (AGENTSPEC_URL + AGENTSPEC_KEY env vars).'
+        : `${total} agent(s) registered, ${withHeartbeat} with active heartbeats.`,
+    },
+  })
 }
 
 // ── Local mode ───────────────────────────────────────────────────────────────

--- a/packages/operator/demo/patches/fitness-tracker-patched-deployment.yaml
+++ b/packages/operator/demo/patches/fitness-tracker-patched-deployment.yaml
@@ -1,0 +1,260 @@
+---
+# Patch for fitness-tracker: adds SDK push mode (heartbeats → control plane).
+#
+# The mock Python server is extended to:
+#   1. Register with the control plane (POST /api/v1/register)
+#   2. Push heartbeats every 15s (POST /api/v1/heartbeat)
+#
+# After this patch the control plane's GET /api/v1/agents returns fitness-tracker
+# with a fresh lastSeen timestamp, and the MCP agentspec_list_agents tool shows
+# heartbeat: true for this agent.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fitness-tracker
+  namespace: demo
+  labels:
+    agentspec.io/agent: fitness-tracker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fitness-tracker
+  template:
+    metadata:
+      labels:
+        app: fitness-tracker
+        agentspec.io/agent: fitness-tracker
+    spec:
+      # MED-2: pod-level security context — all containers inherit runAsNonRoot
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        # ── Agent application container (simulates SDK-integrated LangGraph agent) ──
+        - name: fitness-tracker
+          image: python:3.12.9-slim   # MED-1: pinned patch version, not :latest
+          # Mock server simulating a fully-integrated agentspec SDK agent with push mode.
+          # In addition to the four endpoints the sidecar expects, this version:
+          #   - Registers with the control plane on startup (POST /api/v1/register)
+          #   - Pushes heartbeats every 15s (POST /api/v1/heartbeat)
+          command:
+            - python3
+            - -c
+            - |
+              import json, http.server, datetime, threading, os, urllib.request, urllib.error
+              TOOLS = [
+                {"name": "plan-workout", "description": "Generate a personalised workout plan"},
+                {"name": "log-session",  "description": "Record a completed workout session"},
+                {"name": "get-progress", "description": "Retrieve user progress metrics"},
+              ]
+              def health_report():
+                  return {
+                      "agentName": "fitness-tracker",
+                      "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+                      "status": "healthy",
+                      "summary": {"passed": 5, "failed": 0, "warnings": 0, "skipped": 0},
+                      "checks": [
+                          {"id": "env:GROQ_API_KEY",              "category": "env",   "status": "pass", "severity": "error", "message": "GROQ_API_KEY is set"},
+                          {"id": "model:groq/llama-3.3-70b-versatile", "category": "model", "status": "pass", "severity": "error", "latencyMs": 88},
+                          {"id": "tool:plan-workout",              "category": "tool",  "status": "pass", "severity": "info"},
+                          {"id": "tool:log-session",               "category": "tool",  "status": "pass", "severity": "info"},
+                          {"id": "tool:get-progress",              "category": "tool",  "status": "pass", "severity": "info"},
+                      ],
+                  }
+              class H(http.server.BaseHTTPRequestHandler):
+                  def do_GET(self):
+                      if "agentspec/health" in self.path:
+                          b = json.dumps(health_report()).encode()
+                      elif "cap" in self.path:
+                          b = json.dumps({"tools": TOOLS}).encode()
+                      else:
+                          b = json.dumps({"status": "ok"}).encode()
+                      self.send_response(200)
+                      self.send_header("Content-Type", "application/json")
+                      self.send_header("Content-Length", str(len(b)))
+                      self.end_headers()
+                      self.wfile.write(b)
+                  def log_message(self, *a): pass
+
+              # ── Push mode: register + heartbeat loop ──────────────────────────
+              CP_URL = os.environ.get("AGENTSPEC_CONTROL_PLANE_URL", "")
+              ADMIN_KEY = os.environ.get("AGENTSPEC_ADMIN_KEY", "")
+              _jwt_token = None
+
+              def _post(url, body, headers=None):
+                  data = json.dumps(body).encode()
+                  hdrs = {"Content-Type": "application/json"}
+                  if headers:
+                      hdrs.update(headers)
+                  req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+                  try:
+                      with urllib.request.urlopen(req, timeout=10) as resp:
+                          raw = resp.read().decode()
+                          return json.loads(raw) if raw.strip() else {}
+                  except urllib.error.HTTPError as e:
+                      print(f"[push] HTTP {e.code}: {e.read().decode()[:200]}", flush=True)
+                      return None
+                  except Exception as e:
+                      print(f"[push] error: {e}", flush=True)
+                      return None
+
+              def register():
+                  global _jwt_token
+                  if not CP_URL:
+                      return
+                  url = CP_URL.rstrip("/") + "/api/v1/register"
+                  headers = {}
+                  if ADMIN_KEY:
+                      headers["X-Admin-Key"] = ADMIN_KEY
+                  result = _post(url, {"agentName": "fitness-tracker", "runtime": "k8s"}, headers)
+                  if result and "apiKey" in result:
+                      _jwt_token = result["apiKey"]
+                      print(f"[push] registered with control plane, agentId={result.get('agentId','?')}", flush=True)
+                  else:
+                      print("[push] registration failed, will retry on next heartbeat", flush=True)
+
+              def push_heartbeat():
+                  global _jwt_token
+                  if not CP_URL:
+                      return
+                  if not _jwt_token:
+                      register()
+                      if not _jwt_token:
+                          return
+                  url = CP_URL.rstrip("/") + "/api/v1/heartbeat"
+                  payload = {"health": health_report(), "gap": {"issues": [], "summary": "No gaps detected"}}
+                  _post(url, payload, {"Authorization": f"Bearer {_jwt_token}"})
+
+              def heartbeat_loop():
+                  import time
+                  register()
+                  while True:
+                      time.sleep(15)
+                      push_heartbeat()
+
+              # Start heartbeat in background thread if control plane URL is set
+              if CP_URL:
+                  t = threading.Thread(target=heartbeat_loop, daemon=True)
+                  t.start()
+                  print(f"[push] heartbeat loop started → {CP_URL}", flush=True)
+
+              http.server.HTTPServer(("", 8080), H).serve_forever()
+          env:
+            # GROQ_API_KEY set to demo value — agent reports it as passing in /agentspec/health
+            - name: GROQ_API_KEY
+              value: "sk-agentspec-demo-groq"
+            # Push mode: control plane URL + admin key for registration
+            - name: AGENTSPEC_CONTROL_PLANE_URL
+              value: "http://agentspec-operator-control-plane.agentspec-system.svc.cluster.local"
+            - name: AGENTSPEC_ADMIN_KEY
+              value: "demo-admin-key"
+          ports:
+            - containerPort: 8080
+              name: http
+          # MED-2: container security context
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          # MED-2: resource limits
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+
+        # ── agentspec-sidecar (control plane on port 4001) ───────────────────
+        - name: sidecar
+          image: agentspec/sidecar:local   # MED-1: pinned, not :latest
+          env:
+            - name: UPSTREAM_URL
+              value: "http://localhost:8080"
+            - name: MANIFEST_PATH
+              value: "/config/agent.yaml"
+            - name: OPA_URL
+              value: "http://localhost:8181"
+            - name: OPA_PROXY_MODE
+              value: "enforce"
+            # GROQ_API_KEY set so sidecar static env check passes
+            - name: GROQ_API_KEY
+              value: "sk-agentspec-demo-groq"
+          ports:
+            - containerPort: 4001
+              name: control
+          volumeMounts:
+            - name: agent-manifest
+              mountPath: /config
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health/live
+              port: control
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # MED-2: container security context
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          # MED-2: resource limits
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+
+        # ── OPA policy enforcement sidecar (port 8181) ───────────────────────
+        - name: opa
+          image: openpolicyagent/opa:0.70.0-static   # pinned version, not :latest
+          args:
+            - run
+            - --server
+            - --addr=:8181
+            - --log-level=error
+            - /policies/policy.rego
+            - /policies/data.json
+            - --log-level
+            - error
+          ports:
+            - containerPort: 8181
+              name: opa
+          volumeMounts:
+            - name: opa-policy
+              mountPath: /policies
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: opa
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+
+      volumes:
+        - name: agent-manifest
+          configMap:
+            name: fitness-tracker-agent-yaml
+        - name: opa-policy
+          configMap:
+            name: fitness-tracker-opa-policy

--- a/packages/operator/helm/agentspec-operator/templates/NOTES.txt
+++ b/packages/operator/helm/agentspec-operator/templates/NOTES.txt
@@ -62,22 +62,34 @@ plugins:
 
 {{- if .Values.controlPlane.enabled }}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- RemoteAgentWatcher (cross-runtime visibility)
+ Control Plane
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Control plane deployed at:
+  {{ include "agentspec-operator.controlPlaneUrl" . }}
+
+Port-forward for local access:
+  kubectl port-forward svc/{{ include "agentspec-operator.name" . }}-control-plane -n {{ .Release.Namespace }} 8080:80
+
 {{- if not .Values.controlPlane.apiKey }}
 REQUIRED: Create the control-plane admin key Secret:
 
+  openssl rand -hex 32  # generate a key
   kubectl create secret generic agentspec-control-plane \
     --namespace={{ .Release.Namespace }} \
     --from-literal=apiKey=<your-admin-key>
 
-Then restart the operator:
-  kubectl rollout restart deployment/agentspec-operator -n {{ .Release.Namespace }}
+Then restart both deployments:
+  kubectl rollout restart deployment/{{ include "agentspec-operator.name" . }} -n {{ .Release.Namespace }}
+  kubectl rollout restart deployment/{{ include "agentspec-operator.name" . }}-control-plane -n {{ .Release.Namespace }}
 {{- else }}
 Admin key Secret created from values.controlPlane.apiKey.
 For production, prefer creating the Secret separately to avoid
 storing credentials in Helm release history.
 {{- end }}
+
+MCP / CLI config:
+  AGENTSPEC_CONTROL_PLANE_URL=http://localhost:8080
+  AGENTSPEC_ADMIN_KEY=<same key as controlPlane.apiKey>
 
 Remote agents will appear in k9s :ao under namespace: {{ .Values.controlPlane.namespace | default "agentspec-remote" }}
 {{- end }}

--- a/packages/operator/helm/agentspec-operator/templates/_helpers.tpl
+++ b/packages/operator/helm/agentspec-operator/templates/_helpers.tpl
@@ -43,3 +43,42 @@ Operator image (repo:tag, defaults to Chart.appVersion)
 {{- define "agentspec-operator.image" -}}
 {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
 {{- end }}
+
+{{/*
+Control plane labels
+*/}}
+{{- define "agentspec-operator.controlPlaneLabels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "agentspec-operator.name" . }}-control-plane
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: control-plane
+agentspec.io/role: control-plane
+{{- end }}
+
+{{/*
+Control plane selector labels (stable subset)
+*/}}
+{{- define "agentspec-operator.controlPlaneSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "agentspec-operator.name" . }}-control-plane
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Control plane image (repo:tag)
+*/}}
+{{- define "agentspec-operator.controlPlaneImage" -}}
+{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Control plane internal service URL (auto-resolved when controlPlane.url is empty)
+*/}}
+{{- define "agentspec-operator.controlPlaneUrl" -}}
+{{- if .Values.controlPlane.url -}}
+{{ .Values.controlPlane.url }}
+{{- else -}}
+http://{{ include "agentspec-operator.name" . }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+{{- end }}

--- a/packages/operator/helm/agentspec-operator/templates/check-cert-manager.yaml
+++ b/packages/operator/helm/agentspec-operator/templates/check-cert-manager.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.webhook.enabled .Values.webhook.certManager.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agentspec-operator.name" . }}-check-cert-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentspec-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cert-manager-check
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Values.rbac.serviceAccountName }}
+      containers:
+        - name: check
+          image: bitnami/kubectl:latest
+          command:
+            - sh
+            - -c
+            - |
+              echo "Checking for cert-manager..."
+              if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+                echo "✓ cert-manager CRDs found"
+                if kubectl get deployment -n cert-manager cert-manager >/dev/null 2>&1; then
+                  echo "✓ cert-manager deployment found"
+                  exit 0
+                fi
+              fi
+              echo ""
+              echo "ERROR: cert-manager is required when webhook.enabled=true"
+              echo ""
+              echo "Install it with:"
+              echo "  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml"
+              echo "  kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s"
+              echo ""
+              echo "Or disable the webhook:"
+              echo "  --set webhook.enabled=false"
+              exit 1
+{{- end }}

--- a/packages/operator/helm/agentspec-operator/templates/controlplane-deployment.yaml
+++ b/packages/operator/helm/agentspec-operator/templates/controlplane-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.controlPlane.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentspec-operator.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentspec-operator.controlPlaneLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controlPlane.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "agentspec-operator.controlPlaneSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agentspec-operator.controlPlaneLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "agentspec-operator.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: control-plane
+          image: {{ include "agentspec-operator.controlPlaneImage" . }}
+          imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: AGENTSPEC_ADMIN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: agentspec-control-plane
+                  key: apiKey
+                  optional: true
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: agentspec-control-plane
+                  key: jwtSecret
+                  optional: true
+            - name: DATABASE_URL
+              value: {{ .Values.controlPlane.databaseUrl | default "sqlite+aiosqlite:////data/agentspec.db" | quote }}
+            {{- with .Values.controlPlane.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            {{- toYaml (.Values.controlPlane.resources | default (dict "requests" (dict "cpu" "50m" "memory" "64Mi") "limits" (dict "cpu" "200m" "memory" "256Mi"))) | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          {{- if not .Values.controlPlane.databaseUrl }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+      {{- if not .Values.controlPlane.databaseUrl }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+{{- end }}

--- a/packages/operator/helm/agentspec-operator/templates/controlplane-service.yaml
+++ b/packages/operator/helm/agentspec-operator/templates/controlplane-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.controlPlane.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentspec-operator.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentspec-operator.controlPlaneLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agentspec-operator.controlPlaneSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/packages/operator/helm/agentspec-operator/templates/deployment.yaml
+++ b/packages/operator/helm/agentspec-operator/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             {{- end }}
             {{- if .Values.controlPlane.enabled }}
             - name: CONTROL_PLANE_URL
-              value: {{ .Values.controlPlane.url | quote }}
+              value: {{ include "agentspec-operator.controlPlaneUrl" . | quote }}
             - name: CONTROL_PLANE_KEY
               valueFrom:
                 secretKeyRef:

--- a/packages/operator/helm/agentspec-operator/templates/secret-cp.yaml
+++ b/packages/operator/helm/agentspec-operator/templates/secret-cp.yaml
@@ -6,7 +6,8 @@
 #
 #   kubectl create secret generic agentspec-control-plane \
 #     --namespace={{ .Release.Namespace }} \
-#     --from-literal=apiKey=<your-admin-key>
+#     --from-literal=apiKey=<your-admin-key> \
+#     --from-literal=jwtSecret=<32+ char random string>
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,4 +18,5 @@ metadata:
 type: Opaque
 stringData:
   apiKey: {{ .Values.controlPlane.apiKey | quote }}
+  jwtSecret: {{ .Values.controlPlane.jwtSecret | default (printf "%s-jwt-secret-change-me-in-production" .Values.controlPlane.apiKey) | quote }}
 {{- end }}

--- a/packages/operator/helm/agentspec-operator/values.yaml
+++ b/packages/operator/helm/agentspec-operator/values.yaml
@@ -149,13 +149,54 @@ webhook:
     # The ConfigMap must contain policy.rego and data.json as top-level keys.
     policyConfigMapSuffix: "opa-policy"
 
-# ── RemoteAgentWatcher ────────────────────────────────────────────────────────
-# Polls the control plane and upserts AgentObservation CRs for remote agents
-# (Bedrock, Vertex, Docker, local) into a dedicated namespace.
+# ── Control Plane ─────────────────────────────────────────────────────────────
+# Deploys the AgentSpec control plane (FastAPI REST API) as a sub-component.
+# The operator's RemoteAgentWatcher polls it for cross-runtime agent visibility.
+#
+# When enabled, the control plane is deployed alongside the operator and a
+# ClusterIP Service is created. If url is left empty, it auto-resolves to the
+# internal service URL (http://<name>-control-plane.<namespace>.svc.cluster.local).
 controlPlane:
-  # Set to true to enable RemoteAgentWatcher. Requires url and apiKey.
+  # Set to true to deploy the control plane and enable RemoteAgentWatcher.
   enabled: false
-  url: ""              # e.g. "http://agentspec-control-plane.agentspec-system.svc.cluster.local"
-  apiKey: ""           # admin key for GET /api/v1/agents (X-Admin-Key header)
-  pollInterval: 30     # seconds between polls
+
+  image:
+    repository: ghcr.io/agents-oss/agentspec-control-plane
+    tag: latest   # override with --set controlPlane.image.tag=X.Y.Z
+    pullPolicy: IfNotPresent
+
+  # Override the control plane URL. Leave empty to auto-resolve to the
+  # internal ClusterIP Service created by this chart.
+  url: ""
+
+  # Admin key for the control plane API (X-Admin-Key header).
+  # This same key is used in three places:
+  #   1. Control plane deployment (AGENTSPEC_ADMIN_KEY env var)
+  #   2. Operator RemoteAgentWatcher (CONTROL_PLANE_KEY env var)
+  #   3. MCP server / CLI config (AGENTSPEC_ADMIN_KEY env var)
+  # Empty by default — admin endpoints return 503 until set.
+  apiKey: ""
+
+  pollInterval: 30     # seconds between RemoteAgentWatcher polls
   namespace: agentspec-remote   # namespace where remote CRs are created
+
+  # Database URL for the control plane. Defaults to local SQLite.
+  # For production, use PostgreSQL:
+  #   databaseUrl: "postgresql+asyncpg://user:pass@host:5432/agentspec"
+  databaseUrl: ""      # leave empty for default SQLite at /data/agentspec.db
+
+  # Resource requests/limits for the control plane pod
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+
+  replicas: 1
+
+  # Extra environment variables for the control plane pod
+  env: []
+  # - name: LOG_LEVEL
+  #   value: DEBUG

--- a/packages/operator/operator.py
+++ b/packages/operator/operator.py
@@ -304,7 +304,7 @@ async def startup(settings: kopf.OperatorSettings, **kwargs):
     if os.getenv("WEBHOOK_ENABLED", "false").lower() == "true":
         insecure = os.getenv("WEBHOOK_INSECURE_MODE", "false").lower() == "true"
         if insecure:
-            settings.admission.server = kopf.WebhookServer(port=9443, host="0.0.0.0")
+            settings.admission.server = kopf.WebhookServer(port=9443, host="0.0.0.0", insecure=True)
         else:
             settings.admission.server = kopf.WebhookServer(
                 port=9443,
@@ -400,9 +400,13 @@ async def inject_sidecar(body, spec, name, namespace, patch, logger, **kwargs):
 
     opa_proxy_mode = annotations.get(_OPA_PROXY_MODE_KEY) or _OPA_PROXY_MODE
 
+    # Auto-inject control plane URL when available so agents can push heartbeats
+    cp_url = os.getenv("CONTROL_PLANE_URL", "")
+
     patch_ops = build_sidecar_patch(
         spec, annotations, _INJECT_MODE,
         _OPA_ENABLED, _OPA_IMAGE, opa_proxy_mode, _OPA_POLICY_CONFIGMAP_SUFFIX,
+        control_plane_url=cp_url,
     )
 
     if not patch_ops:

--- a/packages/operator/tests/test_webhook.py
+++ b/packages/operator/tests/test_webhook.py
@@ -369,6 +369,34 @@ class TestBuildSidecarPatchOPA:
         assert all(op["path"] == "/spec/volumes/-" for op in vol_ops)
 
 
+# ── build_sidecar_patch — control plane URL injection ────────────────────────
+
+class TestBuildSidecarPatchControlPlane:
+    def _annotated(self):
+        return {"agentspec.io/inject": "true"}
+
+    def test_control_plane_url_injected_when_set(self):
+        patch = build_sidecar_patch(
+            _pod_spec(), self._annotated(),
+            control_plane_url="http://agentspec-cp.agentspec-system.svc.cluster.local",
+        )
+        sidecar_op = next(op for op in patch if op.get("value", {}).get("name") == "agentspec-sidecar")
+        env = {e["name"]: e["value"] for e in sidecar_op["value"].get("env", [])}
+        assert env.get("AGENTSPEC_CONTROL_PLANE_URL") == "http://agentspec-cp.agentspec-system.svc.cluster.local"
+
+    def test_control_plane_url_not_injected_when_empty(self):
+        patch = build_sidecar_patch(_pod_spec(), self._annotated(), control_plane_url="")
+        sidecar_op = next(op for op in patch if op.get("value", {}).get("name") == "agentspec-sidecar")
+        env_names = [e["name"] for e in sidecar_op["value"].get("env", [])]
+        assert "AGENTSPEC_CONTROL_PLANE_URL" not in env_names
+
+    def test_control_plane_url_not_injected_by_default(self):
+        patch = build_sidecar_patch(_pod_spec(), self._annotated())
+        sidecar_op = next(op for op in patch if op.get("value", {}).get("name") == "agentspec-sidecar")
+        env_names = [e["name"] for e in sidecar_op["value"].get("env", [])]
+        assert "AGENTSPEC_CONTROL_PLANE_URL" not in env_names
+
+
 # ── Excluded namespaces ───────────────────────────────────────────────────────
 
 class TestExcludedNamespaces:

--- a/packages/operator/webhook.py
+++ b/packages/operator/webhook.py
@@ -118,6 +118,7 @@ def build_sidecar_patch(
     opa_image: str = _OPA_IMAGE,
     opa_proxy_mode: str = _OPA_PROXY_MODE,
     opa_policy_configmap_suffix: str = _OPA_POLICY_CONFIGMAP_SUFFIX,
+    control_plane_url: str = "",
 ) -> list[dict[str, Any]]:
     """
     Build the JSON Patch operations to inject the agentspec-sidecar container
@@ -156,6 +157,8 @@ def build_sidecar_patch(
     ]
     if check_interval:
         sidecar_env.append({"name": "AGENTSPEC_CHECK_INTERVAL", "value": check_interval})
+    if control_plane_url:
+        sidecar_env.append({"name": "AGENTSPEC_CONTROL_PLANE_URL", "value": control_plane_url})
     if opa_enabled:
         sidecar_env.append({"name": "OPA_URL", "value": "http://localhost:8181"})
         sidecar_env.append({"name": "OPA_PROXY_MODE", "value": effective_opa_mode})


### PR DESCRIPTION
Deploy the AgentSpec control plane (FastAPI) alongside the operator via Helm, gated by controlPlane.enabled. The chart auto-resolves the internal service URL, creates a Secret with apiKey + jwtSecret, and the operator webhook injects AGENTSPEC_CONTROL_PLANE_URL into every sidecar for automatic push mode registration.

- Add controlplane-deployment.yaml, controlplane-service.yaml, and check-cert-manager.yaml Helm templates
- Add JWT_SECRET env to control plane deployment from shared Secret
- Update secret-cp.yaml to include jwtSecret (auto-derived if not set)
- Update operator.py to pass control_plane_url to webhook patch builder
- Update webhook.py to inject AGENTSPEC_CONTROL_PLANE_URL on sidecars
- Rewrite MCP listAgents to show heartbeat status from lastSeen field, return summary with helpful message when no agents registered
- Fix MCP server: add body size limit, bind to 127.0.0.1, use nullish coalesce for adminKey
- Add fitness-tracker demo patch with push mode (register + heartbeat)
- Update Makefile: demo-operator builds + deploys control plane, demo-patch enables fitness-tracker push mode
- Update docs: operator-helm-values, operating-modes, add-push-mode, quick-start with correct service names and jwtSecret docs