### PR TITLE
docs: flag which CLI commands require an LLM API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ agentspec generate agent.yaml --framework langgraph
 
 ## What you can do
 
+> 🔑 = requires an LLM API key &nbsp;·&nbsp; all other commands are **fully local, no API key needed**
+
 - [x] **Define** your agent in a single `agent.yaml` — model, tools, memory, guardrails, prompts
 - [x] **Validate** schema with instant feedback and path-aware errors
 - [x] **Health-check** all runtime dependencies (env vars, model API, Redis, Postgres, MCP servers)
 - [x] **Audit** compliance against OWASP LLM Top 10, model resilience, and memory hygiene packs
-- [x] **Generate** production-ready LangGraph, CrewAI, Mastra, or AutoGen code via Claude
-- [x] **Scan** an existing codebase and auto-generate the manifest
+- [x] 🔑 **Generate** production-ready LangGraph, CrewAI, Mastra, or AutoGen code
+- [x] 🔑 **Scan** an existing codebase and auto-generate the manifest
 - [x] **Evaluate** agent quality against JSONL datasets with CI pass/fail gates
 - [x] **Deploy** to Kubernetes — operator injects sidecar, exposes `/health/ready` and `/gap`
 - [x] **Export** to A2A / AgentCard format
@@ -51,19 +53,19 @@ agentspec generate agent.yaml --framework langgraph
 # Install
 npm install -g @agentspec/cli
 
-# Create a manifest interactively
+# Create a manifest interactively (no API key needed)
 agentspec init
 
-# Or scan an existing codebase
+# Or scan an existing codebase (🔑 requires LLM API key)
 export ANTHROPIC_API_KEY=your-key
 agentspec scan --dir ./src/
 
-# Validate, health-check, audit
+# Validate, health-check, audit (no API key needed)
 agentspec validate agent.yaml
 agentspec health agent.yaml
 agentspec audit agent.yaml
 
-# Generate runnable code (requires ANTHROPIC_API_KEY)
+# Generate runnable code (🔑 requires LLM API key)
 agentspec generate agent.yaml --framework langgraph --output ./generated/
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,6 +2,17 @@
 
 Get your first AgentSpec manifest validated and health-checked in 5 minutes.
 
+## LLM requirements
+
+Most AgentSpec commands run **fully locally with no API key**. Only two commands call an LLM:
+
+| Command | Requires LLM? | Why |
+|---------|---------------|-----|
+| `validate`, `health`, `audit`, `export`, `diff`, `init` | ✅ No | Pure local logic — schema, probes, rules |
+| `generate` | 🔑 Yes | LLM reasons over your manifest to produce framework code |
+| `scan` | 🔑 Yes | LLM reads your source files to infer the manifest |
+| `evaluate` | ⚡ Indirect | Calls *your agent's* endpoint — uses your agent's own model, not ours |
+
 ## Prerequisites
 
 - [ ] Node.js 20+
@@ -21,7 +32,7 @@ agentspec init
 
 The interactive wizard asks for your agent name, model provider, and which features to enable. It creates `agent.yaml` in the current directory.
 
-### Option B — scan existing code
+### Option B — scan existing code (🔑 requires LLM API key)
 
 Already have an agent codebase? Generate the manifest from source:
 
@@ -31,7 +42,7 @@ agentspec scan --dir ./src/ --dry-run   # preview first
 agentspec scan --dir ./src/             # write agent.yaml
 ```
 
-Claude reads your `.py` / `.ts` / `.js` files and infers model provider, tools, guardrails,
+An LLM reads your `.py` / `.ts` / `.js` files and infers model provider, tools, guardrails,
 memory backend, and required env vars. Review the output — it's a starting point, not a final
 answer.
 
@@ -126,10 +137,10 @@ agentspec audit agent.yaml
 The audit scores your agent against OWASP LLM Top 10 and other compliance packs.
 A minimal agent will score ~45/100 (grade D). Add guardrails, evaluation, and fallback to improve.
 
-## 7. Generate LangGraph code
+## 7. Generate LangGraph code (🔑 requires LLM API key)
 
-Generation uses Claude to reason over your manifest and produce complete, production-ready code.
-Set your Anthropic API key, then run:
+Generation uses an LLM to reason over your manifest and produce complete, production-ready code.
+Set your API key, then run:
 
 ```bash
 export ANTHROPIC_API_KEY=your-api-key-here

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,6 +2,17 @@
 
 All AgentSpec CLI commands. Run via `agentspec` or install globally: `npm i -g @agentspec/cli`.
 
+## LLM requirements at a glance
+
+| Command | Requires LLM API key? |
+|---------|----------------------|
+| `init`, `validate`, `health`, `audit` | ✅ No — fully local |
+| `export`, `diff`, `migrate` | ✅ No — fully local |
+| `generate` | 🔑 Yes |
+| `scan` | 🔑 Yes |
+| `evaluate` | ✅ No (calls your agent's own endpoint) |
+| `generate --deploy k8s` | ✅ No — deterministic templates |
+
 ## `agentspec init`
 
 Interactive wizard to create `agent.yaml`.
@@ -104,7 +115,7 @@ See [Proof Integration Guide](../guides/proof-integration.md) for how to submit 
 
 ## `agentspec generate`
 
-Generate framework-specific agent code using Claude.
+🔑 **Requires an LLM API key.** Generate framework-specific agent code.
 
 ```bash
 agentspec generate <file> --framework <fw> --output <dir>
@@ -207,7 +218,7 @@ Options:
 
 ## `agentspec scan`
 
-Scan a source directory and generate an `agent.yaml` manifest using Claude.
+🔑 **Requires an LLM API key.** Scan a source directory and generate an `agent.yaml` manifest.
 
 ```bash
 agentspec scan --dir ./src/


### PR DESCRIPTION
Add 🔑 indicators to README, quick-start, and CLI reference so users can immediately see that only generate and scan need an API key — everything else runs fully locally.